### PR TITLE
explode(): Passing null to parameter #2 ($string) of type string is d…

### DIFF
--- a/classes/lib_helper.php
+++ b/classes/lib_helper.php
@@ -382,7 +382,7 @@ class lib_helper {
         $memberships = $DB->get_records('local_eduvidual_orgid_userid', array('userid' => $USER->id));
         foreach ($memberships as $membership) {
             $org = $DB->get_record('local_eduvidual_org', array('orgid' => $membership->orgid));
-            $entries = explode("\n", $org->orgmenu);
+            $entries = explode("\n", $org->orgmenu ?? '');
             if (count($entries) > 0) {
                 $orgmenu = array(
                     'entries' => array(),


### PR DESCRIPTION
missing null-Koaleszenz-Operator

https://github.com/center-for-learning-management/moodle-local_eduvidual/issues/184